### PR TITLE
Optimized describe strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /.settings/
 /.project
 /.classpath
+/.idea
+*.iml
+*.ipr
+*.iws


### PR DESCRIPTION
This is similar to the recursive CBD (concise bounded description) strategy which Stardog supports out of the box with a tweak to continue traversing at #-IRIs. It runs in <1s on my laptop. The main difference is reusing the query and not creating the intermediate hash set. It returns the same `18,776` results for `<http://ld.stadt-zuerich.ch/statistics/dataset/GEB-RAUM-ZEIT-NAF-NAM-SEX>` against the data I got from Adrian.